### PR TITLE
Remove I2C simulation toggle and localize memory status labels

### DIFF
--- a/EventHorizon/Pages/Memory.razor
+++ b/EventHorizon/Pages/Memory.razor
@@ -94,6 +94,8 @@
 
     private string GetStatusLabel(MemoryAddress memoryAddress)
     {
-        return memoryAddress.IsDeviceConnected ? "Connected" : "Simulated";
+        return memoryAddress.IsDeviceConnected
+            ? I18n.Translate("MemoryStatusConnected")
+            : I18n.Translate("MemoryStatusSimulated");
     }
 }

--- a/EventHorizon/Pages/SystemConfig.razor
+++ b/EventHorizon/Pages/SystemConfig.razor
@@ -24,13 +24,6 @@
     </div>
     <br />
     <div class="row mb-3">
-        <label for="simulateI2C" class="col-sm-3 col-form-label">@I18n.Translate("SimulateI2CLabel")</label>
-        <div class="col-sm-2">
-            <InputCheckbox @bind-Value="Settings.SimulateI2CDevices" class="form-check-input" id="simulateI2C" />
-        </div>
-    </div>
-    <br />
-    <div class="row mb-3">
         <div class="col-sm-3">
             <button type="button" class="btn btn-primary" @onclick="ExportEvents">@I18n.Translate("ExportEventsButton")</button>
             <br />

--- a/EventHorizon/i18n/de.json
+++ b/EventHorizon/i18n/de.json
@@ -22,7 +22,6 @@
   "SystemConfigurationTitle": "System Configuration",
 
   "TimelineDurationLabel": "Dauer der Timeline in Sekunden",
-  "SimulateI2CLabel": "Simulate I2C Devices",
   "ExportEventsButton": "Exportiere events.json",
   "ImportEventsLabel": "Importiere Events",
 
@@ -41,6 +40,8 @@
   "MemoryListLabel": "Speicheradressen:",
   "MemoryAddressLabel": "Adresse",
   "MemoryNameLabel": "Name",
-  "MemoryIsActiveLabel": "Aktiv"
+  "MemoryIsActiveLabel": "Aktiv",
+  "MemoryStatusConnected": "Verbunden",
+  "MemoryStatusSimulated": "Simuliert"
 
 }

--- a/EventHorizon/i18n/en.json
+++ b/EventHorizon/i18n/en.json
@@ -21,7 +21,6 @@
   "SystemConfigurationTitle": "System Configuration",
 
   "TimelineDurationLabel": "Timeline Duration in Seconds",
-  "SimulateI2CLabel": "Simulate I2C Devices",
   "ExportEventsButton": "Export events.json",
   "ImportEventsLabel": "Import Events",
 
@@ -41,6 +40,8 @@
   "MemoryListLabel": "Memory Addresses:",
   "MemoryAddressLabel": "Address",
   "MemoryNameLabel": "Name",
-  "MemoryIsActiveLabel": "Active"
+  "MemoryIsActiveLabel": "Active",
+  "MemoryStatusConnected": "Connected",
+  "MemoryStatusSimulated": "Simulated"
 
 }

--- a/EventHorizon/i18n/fr.json
+++ b/EventHorizon/i18n/fr.json
@@ -21,7 +21,6 @@
   "SystemConfigurationTitle": "Configuration du système",
 
   "TimelineDurationLabel": "Durée de la chronologie en secondes",
-  "SimulateI2CLabel": "Simuler les appareils I2C",
   "ExportEventsButton": "Exporter events.json",
   "ImportEventsLabel": "Importer des événements",
 
@@ -40,5 +39,7 @@
   "MemoryListLabel": "Adresses de mémoire :",
   "MemoryAddressLabel": "Adresse",
   "MemoryNameLabel": "Nom",
-  "MemoryIsActiveLabel": "Actif"
+  "MemoryIsActiveLabel": "Actif",
+  "MemoryStatusConnected": "Connecté",
+  "MemoryStatusSimulated": "Simulé"
 }

--- a/EventHorizon/src/Memory/MemoryController.cs
+++ b/EventHorizon/src/Memory/MemoryController.cs
@@ -1,29 +1,16 @@
 ﻿using EventHorizon.src.Memory;
-using System.Runtime.InteropServices;
 using Microsoft.EntityFrameworkCore;
-using EventHorizon.src.Util;
 
 public class MemoryController
 {
     private Dictionary<int, MemoryAddress> Addresses;
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly SettingsManager _settings;
-
-    public MemoryController(IServiceScopeFactory scopeFactory, SettingsManager settings)
+    public MemoryController(IServiceScopeFactory scopeFactory)
     {
         Console.WriteLine("Starting Memory");
         _scopeFactory = scopeFactory;
-        _settings = settings;
 
         Addresses = new Dictionary<int, MemoryAddress>(128);
-
-        if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-            (RuntimeInformation.ProcessArchitecture == Architecture.Arm ||
-            RuntimeInformation.ProcessArchitecture == Architecture.Arm64)))
-        {
-            Console.WriteLine("GPIO/I2C not supported on this platform. Simulating devices...");
-            _settings.SimulateI2CDevices = true;
-        }
         genrateAddresses();
 
         Console.WriteLine("finished initializing Memory addresses");
@@ -33,7 +20,7 @@ public class MemoryController
     {
         for (int i = 0; i < 8; i++)
         {
-            IMemoryDevice dev = new DynamicMemoryDevice(1, 32 + i, !_settings.SimulateI2CDevices);
+            IMemoryDevice dev = new DynamicMemoryDevice(1, 32 + i, false);
             generateMemoryAddr(i, dev);
         }
     }

--- a/EventHorizon/src/Util/Settings.cs
+++ b/EventHorizon/src/Util/Settings.cs
@@ -6,7 +6,6 @@ namespace EventHorizon.src.Util
     {
         [Key]
         public int Id { get; set; } = 1;
-        public bool SimulateI2CDevices { get; set; } = false;
         public int TimelineDuration { get; set; } = 180;
     }
 }

--- a/EventHorizon/src/Util/SettingsManager.cs
+++ b/EventHorizon/src/Util/SettingsManager.cs
@@ -8,7 +8,6 @@ namespace EventHorizon.src.Util
         private readonly IServiceScopeFactory _scopeFactory;
 
 
-        public bool SimulateI2CDevices { get; set; } = false;
         public int TimelineDuration { get; set; } = 180;
 
         public SettingsManager(IServiceScopeFactory scopeFactory)
@@ -17,14 +16,6 @@ namespace EventHorizon.src.Util
             Console.WriteLine("Loading Configuration");
             LoadSettings();
 
-            foreach (String arg in Environment.GetCommandLineArgs())
-            {
-                if (arg.Contains("--simulateI2C") && !SimulateI2CDevices)
-                {
-                    SimulateI2CDevices = true;
-                    Console.WriteLine("Simulating I2CDevices");
-                }
-            }
         }
 
         public void SaveSettings()
@@ -37,14 +28,12 @@ namespace EventHorizon.src.Util
                 settingsEntity = new Settings
                 {
                     Id = 1,
-                    SimulateI2CDevices = SimulateI2CDevices,
                     TimelineDuration = TimelineDuration
                 };
                 dbContext.Settings.Add(settingsEntity);
             }
             else
             {
-                settingsEntity.SimulateI2CDevices = SimulateI2CDevices;
                 settingsEntity.TimelineDuration = TimelineDuration;
                 dbContext.Settings.Update(settingsEntity);
             }
@@ -62,7 +51,6 @@ namespace EventHorizon.src.Util
             var settingsEntity = dbContext.Settings.AsNoTracking().FirstOrDefault(s => s.Id == 1);
             if (settingsEntity != null)
             {
-                SimulateI2CDevices = settingsEntity.SimulateI2CDevices;
                 TimelineDuration = settingsEntity.TimelineDuration;
                 Console.WriteLine("Settings loaded.");
             }


### PR DESCRIPTION
### Motivation
- I2C devices are now always simulated so the runtime toggle and setting for enabling/disabling I2C simulation are no longer needed.
- The memory status labels were hard-coded and need to be part of the existing i18n structure for proper localization.

### Description
- Removed the `SimulateI2CDevices` setting and related handling from `Settings` and `SettingsManager`, including command-line parsing and persistence updates.
- Removed the `Simulate I2C Devices` checkbox from `Pages/SystemConfig.razor` UI.
- Updated `MemoryController` to drop the `SettingsManager` dependency and always instantiate `DynamicMemoryDevice(..., false)` so devices are created in simulated mode.
- Replaced hard-coded status labels in `Pages/Memory.razor` with `I18n.Translate("MemoryStatusConnected")` / `I18n.Translate("MemoryStatusSimulated")` and added those keys to the `i18n` JSON files (`en.json`, `de.json`, `fr.json`).

### Testing
- No automated tests were run for this change.
- (No automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffdb58f7c8327af0fff4a66fc369e)