### PR TITLE
Expand beta build platforms to include linux-arm and linux-arm64

### DIFF
--- a/.github/workflows/beta-build.yml
+++ b/.github/workflows/beta-build.yml
@@ -1,0 +1,35 @@
+name: Beta Build
+
+on:
+  push:
+    branches:
+      - work
+  workflow_dispatch:
+
+jobs:
+  beta-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runtime: linux-x64
+          - runtime: linux-arm
+          - runtime: linux-arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build and Package Application
+        run: |
+          dotnet publish ./EventHorizon/EventHorizon.csproj -c Release -r ${{ matrix.runtime }} --self-contained false -o ./output/${{ matrix.runtime }}
+
+      - name: Upload beta artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: eventhorizon-beta-${{ matrix.runtime }}-${{ github.sha }}
+          path: ./output/${{ matrix.runtime }}


### PR DESCRIPTION
### Motivation
- Provide beta build artifacts for additional platforms beyond `linux-x64` to cover ARM-based environments.
- Maintain a lightweight, triggerable pipeline for the `work` branch to support downstream testing and QA.

### Description
- Updated `/.github/workflows/beta-build.yml` to expand the job matrix to include `linux-arm` and `linux-arm64` alongside `linux-x64`.
- The workflow still uses `actions/setup-dotnet@v3` with `8.0.x` and runs `dotnet publish ./EventHorizon/EventHorizon.csproj -c Release -r ${{ matrix.runtime }} --self-contained false -o ./output/${{ matrix.runtime }}` for each matrix runtime.
- Each publish output is uploaded as an artifact named `eventhorizon-beta-${{ matrix.runtime }}-${{ github.sha }}` using `actions/upload-artifact@v4`.

### Testing
- No automated tests were executed as part of this change because the workflow runs on GitHub Actions infrastructure.
- The workflow is configured to run on push to `work` or via `workflow_dispatch` and will produce artifacts when executed on GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500071cb108327a199f65ea9310f93)