### PR TITLE
Respect existing device names when generating memory addresses

### DIFF
--- a/EventHorizon/src/Memory/MemoryAddress.cs
+++ b/EventHorizon/src/Memory/MemoryAddress.cs
@@ -28,7 +28,7 @@ public class MemoryAddress
     {
         Address = addr;
         Device = dev;
-        Name = Device.GetType().Name + "" + addr.ToString();
+        Name = string.Empty;
         IsActive = Device.GetIsActive(Address);
     }
 
@@ -42,5 +42,4 @@ public class MemoryAddress
     { return Device.GetIsActive(Address); }
 
 }
-
 

--- a/EventHorizon/src/Memory/MemoryController.cs
+++ b/EventHorizon/src/Memory/MemoryController.cs
@@ -79,11 +79,20 @@ public class MemoryController
             if (existingAddress != null)
             {
                 existingAddress.Device = dev;
+                if (string.IsNullOrWhiteSpace(existingAddress.Name))
+                {
+                    existingAddress.Name = $"Device {i + 1}";
+                }
                 Addresses.Add(addr, existingAddress);
             }
             else
             {
-                Addresses.Add(addr, new MemoryAddress(addr, dev));
+                var memoryAddress = new MemoryAddress(addr, dev);
+                if (string.IsNullOrWhiteSpace(memoryAddress.Name))
+                {
+                    memoryAddress.Name = $"Device {i + 1}";
+                }
+                Addresses.Add(addr, memoryAddress);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Avoid overwriting user-saved device names when memory addresses are reloaded from the database.
- Only assign a default label like `Device N` when there is no existing name for that memory address.
- Stop auto-deriving the address `Name` from the device type and address in the constructor to prevent unintended overrides.

### Description
- Updated the `MemoryAddress` constructor to stop setting a generated name and instead initialize `Name` to an empty string in `MemoryAddress.cs`.
- Modified `generateMemoryAddr` in `MemoryController.cs` to preserve existing `Name` values and only set `Name = $"Device {i + 1}"` when `string.IsNullOrWhiteSpace(...)` is true for both existing and newly created addresses.
- Ensured the device instance is assigned to `existingAddress.Device` and that new addresses are created into a local `memoryAddress` variable before possibly assigning a default name.
- Changes applied to `EventHorizon/src/Memory/MemoryAddress.cs` and `EventHorizon/src/Memory/MemoryController.cs`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff49b71048327a06044704f7ee924)