### PR TITLE
Fix timeline event ordering and memory toggle binding

### DIFF
--- a/EventHorizon/Pages/Memory.razor
+++ b/EventHorizon/Pages/Memory.razor
@@ -14,7 +14,9 @@
 
             <!-- checkbox for active/inactive -->
             <label class="switch">
-                <input type="checkbox" @bind="memoryAddressEntry.Value.IsActive" @onclick="() => memoryAddressEntry.Value.Update(memoryAddressEntry.Value.IsActive)">
+                <input type="checkbox"
+                       @bind="memoryAddressEntry.Value.IsActive"
+                       @bind:after="() => memoryAddressEntry.Value.Update(memoryAddressEntry.Value.IsActive)">
                 <span class="slider round"></span>
             </label>
 

--- a/EventHorizon/src/TimeLine/TimeLineController.cs
+++ b/EventHorizon/src/TimeLine/TimeLineController.cs
@@ -7,7 +7,7 @@ public class TimeLineController
     private readonly EventManager _eventManager;
     private readonly MemoryController _memoryController;
     private readonly SettingsManager _settingsManager;
-    public Stack<TimeLineEvent> TimeLineEvents { get; set; }
+    public Queue<TimeLineEvent> TimeLineEvents { get; set; }
     List<TimeLineEvent> UpcomingTimeLineEvents { get; set; }
     public int Duration { get; set; }
     public int currentTime = 0;
@@ -23,7 +23,7 @@ public class TimeLineController
         Duration = _settingsManager.TimelineDuration;
         CurrentPlayState = TimeLinePlayState.Play;
 
-        TimeLineEvents = new Stack<TimeLineEvent>();
+        TimeLineEvents = new Queue<TimeLineEvent>();
         UpcomingTimeLineEvents = new List<TimeLineEvent>();
         GenerateTimeLine();
         Reset();
@@ -43,13 +43,10 @@ public class TimeLineController
 
                 if (currentTime <= Duration)
                 {
-                    if (TimeLineEvents.Count > 0)
+                    while (TimeLineEvents.Count > 0 && TimeLineEvents.Peek().ExecutionTime <= currentTime)
                     {
-                        while (TimeLineEvents.Count > 0 && TimeLineEvents.Peek().ExecutionTime <= currentTime)
-                        {
-                            TimeLineEvents.Peek().Address.Update(TimeLineEvents.Peek().IsActive);
-                            TimeLineEvents.Pop();
-                        }
+                        var timeLineEvent = TimeLineEvents.Dequeue();
+                        timeLineEvent.Address.Update(timeLineEvent.IsActive);
                     }
                 }
                 else
@@ -101,7 +98,7 @@ public class TimeLineController
 
     private void Reset()
     {
-        TimeLineEvents = new Stack<TimeLineEvent>(UpcomingTimeLineEvents);
+        TimeLineEvents = new Queue<TimeLineEvent>(UpcomingTimeLineEvents);
         UpcomingTimeLineEvents = new List<TimeLineEvent>();
         GenerateTimeLine();
         currentTime = 0;

--- a/EventHorizon/src/TimeLine/TimeLineEvent.cs
+++ b/EventHorizon/src/TimeLine/TimeLineEvent.cs
@@ -29,7 +29,7 @@ namespace EventHorizon.src.TimeLine
                 return 1;
 
             else
-                return ExecutionTime <= other.ExecutionTime ? 1 : -1;
+                return ExecutionTime.CompareTo(other.ExecutionTime);
         }
 
         public override int GetHashCode()
@@ -51,4 +51,3 @@ namespace EventHorizon.src.TimeLine
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- Timeline events were being processed in the wrong order due to LIFO semantics and a faulty comparison implementation. 
- The `TimeLineEvent.CompareTo` returned inverted ordering which caused start/end states to flip. 
- Using a `Stack` caused last-in-first-out processing instead of chronological execution. 
- Memory checkbox updates fired before the bound value change reached the model, causing one-off toggling behavior.

### Description
- Replace `Stack<TimeLineEvent>` with `Queue<TimeLineEvent>` and populate it in chronological order so events are processed FIFO. 
- Fix `TimeLineEvent.CompareTo` to use `ExecutionTime.CompareTo(other.ExecutionTime)` for correct sorting. 
- Update timeline processing loop to `Dequeue()` events and call `Address.Update(...)` on the dequeued item. 
- Change the memory checkbox binding to use `@bind:after` so `MemoryAddress.Update(...)` runs after the UI value has been applied.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951651a43fc832788716c7a31932b91)