### PR TITLE
Initialize memory outputs according to invert setting

### DIFF
--- a/EventHorizon/src/Memory/MemoryDevice.cs
+++ b/EventHorizon/src/Memory/MemoryDevice.cs
@@ -13,8 +13,8 @@ namespace EventHorizon.src.Memory
         public MemoryDevice(Mcp23017 device, bool invertOutputs)
         {
             Dev = device;
-            Values.SetAll(false);
             _invertOutputs = invertOutputs;
+            Values.SetAll(GetHardwareState(false));
            
         }
         public void UpdatePin(int Id, bool IsActive)

--- a/EventHorizon/src/Memory/MemoryDeviceDummy.cs
+++ b/EventHorizon/src/Memory/MemoryDeviceDummy.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Iot.Device.Mcp23xxx;
-
+ //comment
 namespace EventHorizon.src.Memory
 {
     public class MemoryDeviceDummy : IMemoryDevice

--- a/EventHorizon/src/Memory/MemoryDeviceDummy.cs
+++ b/EventHorizon/src/Memory/MemoryDeviceDummy.cs
@@ -11,6 +11,7 @@ namespace EventHorizon.src.Memory
         public MemoryDeviceDummy(bool invertOutputs)
         {
             _invertOutputs = invertOutputs;
+            IsActive = _invertOutputs ? true : false;
         }
 
 		public bool GetIsActive(int ID)


### PR DESCRIPTION
### Motivation
- Fix mismatches between stored/visible memory states and actual hardware state when `InvertMemoryOutputs` is enabled.
- Prevent timeline-driven toggles from appearing inverted or shifted (e.g. first click no-op then second click toggles) caused by incorrect initial pin values.

### Description
- Initialize the `BitArray` in `MemoryDevice` using `GetHardwareState(false)` so default hardware bits respect the `invertOutputs` setting. 
- Set the dummy device initial `IsActive` in `MemoryDeviceDummy` to `true` when `_invertOutputs` is `true` so simulated devices match inverted behavior. 
- Changes applied to `EventHorizon/src/Memory/MemoryDevice.cs` and `EventHorizon/src/Memory/MemoryDeviceDummy.cs`.

### Testing
- No automated tests were run as part of this change.
- Manual verification recommended: start with `InvertMemoryOutputs` both `true` and `false` and verify initial device states, timeline activations, and single-button toggles behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952516bed34832781069d0b477cc6be)